### PR TITLE
Remove unnecessary requests requirement

### DIFF
--- a/custom_components/solarcore_energy/manifest.json
+++ b/custom_components/solarcore_energy/manifest.json
@@ -2,11 +2,13 @@
   "domain": "solarcore_energy",
   "name": "Solarcore Energy",
   "description": "A custom integration for Solarcore Energy",
-  "configuration_url": "https://github.com/ErwinSt/home-assistant-solarcore-energy",  
+  "configuration_url": "https://github.com/ErwinSt/home-assistant-solarcore-energy",
   "documentation": "https://github.com/ErwinSt/home-assistant-solarcore-energy",
   "dependencies": [],
-  "codeowners": ["@ErwinSt"],
-  "requirements": ["requests"],
+  "codeowners": [
+    "@ErwinSt"
+  ],
+  "requirements": [],
   "version": "1.0.0",
   "config_flow": true,
   "integration_type": "hub",


### PR DESCRIPTION
## Summary
- remove `requests` requirement from integration manifest

## Testing
- `python -m json.tool custom_components/solarcore_energy/manifest.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c54d8e7a9483229b8743abd7e9569d