### PR TITLE
Refactor sensors using descriptions and add French translations

### DIFF
--- a/custom_components/solarcore_energy/translations/en.json
+++ b/custom_components/solarcore_energy/translations/en.json
@@ -6,5 +6,21 @@
                 "description": "Enter your Rockcore account credentials"
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "power_total": {"name": "Total Power"},
+            "power1": {"name": "Power 1"},
+            "power2": {"name": "Power 2"},
+            "vol1": {"name": "Voltage 1"},
+            "vol2": {"name": "Voltage 2"},
+            "current1": {"name": "Current 1"},
+            "current2": {"name": "Current 2"},
+            "gridseq": {"name": "Grid Freq"},
+            "gridvolc": {"name": "Grid Voltage"},
+            "temp": {"name": "Temperature"},
+            "total_energy": {"name": "Total Energy"},
+            "today_energy": {"name": "Today Energy"}
+        }
     }
 }

--- a/custom_components/solarcore_energy/translations/fr.json
+++ b/custom_components/solarcore_energy/translations/fr.json
@@ -1,0 +1,26 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Rockcore Solar",
+                "description": "Entrez vos identifiants Rockcore"
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "power_total": {"name": "Puissance totale"},
+            "power1": {"name": "Puissance 1"},
+            "power2": {"name": "Puissance 2"},
+            "vol1": {"name": "Tension 1"},
+            "vol2": {"name": "Tension 2"},
+            "current1": {"name": "Courant 1"},
+            "current2": {"name": "Courant 2"},
+            "gridseq": {"name": "Fréquence du réseau"},
+            "gridvolc": {"name": "Tension du réseau"},
+            "temp": {"name": "Température"},
+            "total_energy": {"name": "Énergie totale"},
+            "today_energy": {"name": "Énergie du jour"}
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define sensors via `SensorEntityDescription`
- use descriptions to build entities
- add English and French sensor translations

## Testing
- `python -m py_compile custom_components/solarcore_energy/sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5544dcf6c8322a7ee4b7d0306a70f