### PR TITLE
Add station event service

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ Easily track your solar power, voltage, temperature and total energy generation 
 - Your login (email + password)
 - Internet access (for cloud API)
 
+## 📣 Station Event Service
+
+This integration exposes the `station_event` service. It can be used to
+dispatch custom events about a station.
+
+```yaml
+service: solarcore_energy.station_event
+data:
+  station_id: "12345"
+  type: "error"
+```
+
+### Example Automation: Mobile Notification
+
+```yaml
+automation:
+  - alias: Solarcore alert
+    trigger:
+      platform: event
+      event_type: solarcore_energy_station_event
+    action:
+      - service: notify.mobile_app_my_phone
+        data:
+          message: >-
+            Station {{ trigger.event.data.station_id }} reported {{ trigger.event.data.type }}
+```
+
 ## 💡 Ideas & Next Steps
 
 - Add local IP support (reverse-engineered API)

--- a/custom_components/solarcore_energy/__init__.py
+++ b/custom_components/solarcore_energy/__init__.py
@@ -1,11 +1,33 @@
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from .const import DOMAIN
 
 PLATFORMS = ["sensor"]
 
-from .const import DOMAIN
+SERVICE_STATION_EVENT = "station_event"
+STATION_EVENT_SCHEMA = vol.Schema(
+    {
+        vol.Required("station_id"): cv.string,
+        vol.Required("type"): cv.string,
+    }
+)
 
 async def async_setup(hass: HomeAssistant, config: dict):
+    async def handle_station_event(call: ServiceCall):
+        hass.bus.async_fire(
+            f"{DOMAIN}_{SERVICE_STATION_EVENT}",
+            {
+                "station_id": call.data["station_id"],
+                "type": call.data["type"],
+            },
+        )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_STATION_EVENT, handle_station_event, STATION_EVENT_SCHEMA
+    )
+
     return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):


### PR DESCRIPTION
## Summary
- expose `station_event` service for Solarcore integrations
- document service with example notification automation

## Testing
- `ruff check custom_components/solarcore_energy/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5583c1ce48322a2ee212c10b784b7