### PR TITLE
Use currency code for estimated savings sensor

### DIFF
--- a/custom_components/solarcore_energy/sensor.py
+++ b/custom_components/solarcore_energy/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import UnitOfCurrency
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -134,7 +135,7 @@ SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="estimated_savings",
         translation_key="estimated_savings",
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="€",
+        native_unit_of_measurement=UnitOfCurrency.EURO,
         state_class=SensorStateClass.MEASUREMENT,
     ),
 ]


### PR DESCRIPTION
## Summary
- Use `UnitOfCurrency.EURO` as the unit for estimated savings
- Import `UnitOfCurrency` for monetary sensor

## Testing
- `pytest`
- `python -m py_compile custom_components/solarcore_energy/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c568fe2264832290881abe633bcc6a