### PR TITLE
Prevent duplicate configuration entries for the same account

### DIFF
--- a/custom_components/solarcore_energy/config_flow.py
+++ b/custom_components/solarcore_energy/config_flow.py
@@ -46,6 +46,9 @@ class RockcoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except (KeyError, ValueError):
                 errors["base"] = "auth"
             else:
+                await self.async_set_unique_id(user_input[CONF_USERNAME])
+                self._abort_if_unique_id_configured()
+
                 return self.async_create_entry(
                     title="Rockcore Solar", data=user_input
                 )


### PR DESCRIPTION
## Summary
- Ensure user account serves as unique ID during configuration flow
- Abort configuration when account already exists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c56e2991d48322a0bd68dc20379899