### PR TITLE
Use native_value property for Rockcore sensors

### DIFF
--- a/custom_components/solarcore_energy/sensor.py
+++ b/custom_components/solarcore_energy/sensor.py
@@ -178,7 +178,9 @@ class RockcoreSensor(CoordinatorEntity, SensorEntity):
         self._attr_has_entity_name = True
 
     @property
-    def state(self):
+    def native_value(self):
+        """Return the value reported by the sensor in its native unit."""
+
         value = self.coordinator.data.get(self.station_id, {}).get(self.key)
         if isinstance(value, str):
             for suffix in ["W", "V", "A", "Hz", "℃", "°C", "kWh", "Wh"]:


### PR DESCRIPTION
## Summary
- rename sensor state property to native_value and compute numeric value

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c56eaf5d708322a46b1647a4810423