### PR TITLE
Handle unit conversion for Rockcore sensor values

### DIFF
--- a/custom_components/solarcore_energy/sensor.py
+++ b/custom_components/solarcore_energy/sensor.py
@@ -36,6 +36,7 @@ from .const import (
     STATION_LIST_ENDPOINT,
 )
 from .forecast import async_calculate_forecast
+from .util import parse_value
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -184,14 +185,7 @@ class RockcoreSensor(CoordinatorEntity, SensorEntity):
         """Return the value reported by the sensor in its native unit."""
 
         value = self.coordinator.data.get(self.station_id, {}).get(self.key)
-        if isinstance(value, str):
-            for suffix in ["W", "V", "A", "Hz", "℃", "°C", "kWh", "Wh"]:
-                value = value.replace(suffix, "")
-            try:
-                return float(value)
-            except ValueError:
-                return None
-        return value
+        return parse_value(value)
 
     # Removed async_update as it's handled by CoordinatorEntity
 

--- a/custom_components/solarcore_energy/util.py
+++ b/custom_components/solarcore_energy/util.py
@@ -1,0 +1,46 @@
+"""Utility helpers for Solarcore Energy integration."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def parse_value(value: Any) -> Optional[float]:
+    """Parse a numeric value from API strings.
+
+    The Rockcore API often returns values as strings with units such as
+    ``"0.5kW"`` or ``"500Wh"``. This helper converts those strings to floats
+    expressed in the integration's native units:
+
+    * Power values are returned in watts.
+    * Energy values are returned in kilowatt-hours.
+    * Other units like ``V``, ``A``, ``Hz`` and ``°C`` are stripped.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    text = str(value).strip().lower()
+
+    multipliers = {
+        "kw": 1000.0,  # kilowatts -> watts
+        "w": 1.0,      # watts
+        "kwh": 1.0,    # kilowatt-hours
+        "wh": 0.001,   # watt-hours -> kilowatt-hours
+    }
+    for unit, multiplier in multipliers.items():
+        if text.endswith(unit):
+            text = text[:-len(unit)]
+            try:
+                return float(text) * multiplier
+            except (TypeError, ValueError):
+                return None
+
+    for suffix in ["v", "a", "hz", "℃", "°c"]:
+        text = text.replace(suffix, "")
+
+    try:
+        return float(text)
+    except (TypeError, ValueError):
+        return None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "solarcore_energy"
+    / "util.py"
+)
+spec = importlib.util.spec_from_file_location("util", MODULE_PATH)
+util = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(util)
+parse_value = util.parse_value
+
+
+def test_parse_power_kw():
+    assert parse_value("0.5kW") == 500.0
+
+
+def test_parse_energy_wh():
+    assert parse_value("500Wh") == 0.5
+
+
+def test_parse_temperature():
+    assert parse_value("42°C") == 42.0
+
+
+def test_parse_invalid():
+    assert parse_value("N/A") is None


### PR DESCRIPTION
## Summary
- Add `parse_value` helper to normalize Rockcore API strings
- Use helper in Rockcore sensor `native_value` to handle kW/Wh and other units
- Add unit tests for parsing logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57a33642c8322a92b203365a38d07