### PR TITLE
Fix config flow import error by decoupling sensor constants

### DIFF
--- a/custom_components/solarcore_energy/config_flow.py
+++ b/custom_components/solarcore_energy/config_flow.py
@@ -13,8 +13,8 @@ from .const import (
     DEFAULT_COST_PER_KWH,
     DOMAIN,
     LOGIN_ENDPOINT,
+    SENSOR_KEYS,
 )
-from .sensor import SENSOR_TYPES
 
 
 class RockcoreConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -95,8 +95,8 @@ class RockcoreOptionsFlow(config_entries.OptionsFlow):
                     ): vol.Coerce(float),
                     vol.Optional(
                         CONF_SENSORS,
-                        default=options.get(CONF_SENSORS, list(SENSOR_TYPES.keys())),
-                    ): cv.multi_select(list(SENSOR_TYPES.keys())),
+                        default=options.get(CONF_SENSORS, SENSOR_KEYS),
+                    ): cv.multi_select(SENSOR_KEYS),
                 }
             ),
         )

--- a/custom_components/solarcore_energy/const.py
+++ b/custom_components/solarcore_energy/const.py
@@ -10,6 +10,24 @@ DEFAULT_UPDATE_INTERVAL = 30
 CONF_COST_PER_KWH = "cost_per_kwh"
 DEFAULT_COST_PER_KWH = 0.2
 
+# Sensor keys used by config and options flow
+SENSOR_KEYS = [
+    "power_total",
+    "power1",
+    "power2",
+    "vol1",
+    "vol2",
+    "current1",
+    "current2",
+    "gridseq",
+    "gridvolc",
+    "temp",
+    "total_energy",
+    "today_energy",
+    "forecast_energy",
+    "estimated_savings",
+]
+
 BASE_URL = "http://gf.rockcore-energy.com:9721/rcmi-manager"
 LOGIN_ENDPOINT = f"{BASE_URL}/client/login"
 STATION_LIST_ENDPOINT = f"{BASE_URL}/station/queryStationInfoList"


### PR DESCRIPTION
## Summary
- avoid importing sensor module in config flow to prevent invalid handler error
- define `SENSOR_KEYS` in const for options schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57dabec9883229121cb7a44be98e7